### PR TITLE
Try Catch Support

### DIFF
--- a/project/1.ssc
+++ b/project/1.ssc
@@ -5,5 +5,5 @@ b = 0;
 
 }
 catch (division_by_zero) {   
- prints("Division by zero");
+    printe("Division by zero");
 }

--- a/project/IR.h
+++ b/project/IR.h
@@ -1,3 +1,4 @@
+#include <exception>
 #include <map>
 #include <setjmp.h>
 #include <stack>
@@ -6,7 +7,8 @@
 #include <string>
 using namespace std;
 
-static map<string, double> symbolTable;
+static map<string, double> doubleSymbolTable;
+static map<string, string> stringSymbolTable;
 static stack<string> exceptionStack;
 bool exceptionThrown = false;
 
@@ -30,9 +32,11 @@ double performBinaryOperation(double lhs, double rhs, int op) {
   case '/':
     if (rhs == 0) {
       exceptionThrown = true;
-      string msg = "Division by zero: Attempted to divide " + to_string(lhs) +
+/*       string msg = "Division by zero: Attempted to divide " + to_string(lhs) +
                    " by " + to_string(rhs);
-      throw CustomException(msg);
+      exceptionStack.push(msg);
+      exceptionThrown = false;
+      throw CustomException(msg); */
     }
     return lhs / rhs;
   default:
@@ -46,40 +50,35 @@ void print(const char *format, double value) { printf(format, value); }
 
 void setValueInSymbolTable(const char *id, double value) {
   string name(id);
-  symbolTable[name] = value;
+  doubleSymbolTable[name] = value;
+}
+
+void setValueInStringSymbolTable(const char *id, const char *value) {
+  string name(id);
+  stringSymbolTable[name] = string(value);
 }
 
 double getValueFromSymbolTable(const char *id) {
   string name(id);
-  if (symbolTable.find(name) != symbolTable.end()) {
-    return symbolTable[name];
+  if (doubleSymbolTable.find(name) != doubleSymbolTable.end()) {
+    return doubleSymbolTable[name];
   }
   return 0;
 }
 
+string getValueFromStringSymbolTable(const char *id) {
+  string name(id);
+  if (stringSymbolTable.find(name) != stringSymbolTable.end()) {
+    return stringSymbolTable[name];
+  }
+  return "";
+}
+
+bool isExceptionThrown() { return exceptionThrown; }
+void setExceptionThrown(bool value) { exceptionThrown = value; }
 void throwException(const char *exceptionType) {
   string exType(exceptionType);
   exceptionStack.push(exType);
+  exceptionThrown = true;
   throw CustomException(exType);
-}
-
-void tryBlock(void (*tryBlock)()) {
-  if (tryBlock == nullptr) {
-    return;
-  }
-  printf("%s",*tryBlock);
-}
-
-void CatchBlock(void (*catchBlock)(), const char *exception) {
-  if(!exceptionThrown){
-    return;
-  }
-  else if (catchBlock == nullptr) {
-    return;
-  }
-  else if (exceptionThrown) {
-    catchBlock();
-    throwException(exception);
-    exceptionThrown = false;
-  }
 }

--- a/project/ssc.l
+++ b/project/ssc.l
@@ -19,6 +19,7 @@
 
 "printd"                {debugFlex(tok_printd); return tok_printd;}
 "prints"                {debugFlex(tok_prints); return tok_prints;}
+"printe"                {debugFlex(tok_printe); return tok_printe;}
 "try"                   {debugFlex(tok_try); return tok_try;}
 "catch"                 {debugFlex(tok_catch); return tok_catch;}
 "throw"                 {debugFlex(tok_throw); return tok_throw;}

--- a/project/tests/try_catch/2.ssc
+++ b/project/tests/try_catch/2.ssc
@@ -1,5 +1,6 @@
 try {
-    printd(10 / 2);
+    a = 10 / 2;
+    printd(a);
 } catch (DivisionByZero) {
-    prints("Caught division by zero exception");
+    printe("Caught division by zero exception");
 }

--- a/project/tests/try_catch/3.ssc
+++ b/project/tests/try_catch/3.ssc
@@ -1,10 +1,12 @@
 try {
     try {
-        printd(10 / 0);
+        a = 10 / 0;
+        printd(a);
     } catch (DivisionByZero) {
-        prints("Caught inner division by zero exception");
+        printe("Caught inner division by zero exception");
     }
-    printd(10 / 2);
+    a = 10 / 2;
+    printd(a);
 } catch (DivisionByZero) {
-    prints("Caught outer division by zero exception");
+    printe("Caught outer division by zero exception");
 }

--- a/project/tests/try_catch/5.ssc
+++ b/project/tests/try_catch/5.ssc
@@ -1,5 +1,5 @@
 try {
     throw(CustomException);
 } catch (CustomException) {
-    prints("Caught custom exception");
+    printe("Caught custom exception");
 }

--- a/project/tests/try_catch/6.ssc
+++ b/project/tests/try_catch/6.ssc
@@ -1,5 +1,6 @@
 try {
-    printd(5 * 5);
+    a = 5 * 5;
+    printd(a);
 } catch (DivisionByZero) {
-    prints("Caught division by zero exception");
+    printe("Caught division by zero exception");
 }


### PR DESCRIPTION
- Add modules and tests for try catch support.
- addition of a new `printe` token.

### Exception handling improvements:

* [`project/1.ssc`](diffhunk://#diff-e221de3ca539ef476c16836d43b5404260c9ce2de0c3b62212860fd908366c26L8-R8): Modified the catch block to use `printe` instead of `prints` for division by zero errors.
* [`project/ssc.l`](diffhunk://#diff-a6635cf1f3f24f6fc276eba503162a861c6bd0c4a645f0389a56cd0a686c3d77R22): Added a new token `printe` for printing exception messages.
* [`project/ssc.y`](diffhunk://#diff-b27260440cf501152d8b147b48828c59fe1b3b60f5ba4cafde7744e616bfe3c8L22-R36): Updated the grammar to handle the new `printe` token and revised the try-catch structure to properly manage exceptions and their messages. [[1]](diffhunk://#diff-b27260440cf501152d8b147b48828c59fe1b3b60f5ba4cafde7744e616bfe3c8L22-R36) [[2]](diffhunk://#diff-b27260440cf501152d8b147b48828c59fe1b3b60f5ba4cafde7744e616bfe3c8L53-R60) [[3]](diffhunk://#diff-b27260440cf501152d8b147b48828c59fe1b3b60f5ba4cafde7744e616bfe3c8R69-R71) [[4]](diffhunk://#diff-b27260440cf501152d8b147b48828c59fe1b3b60f5ba4cafde7744e616bfe3c8L88-R109)

### Symbol table management:

* [`project/IR.h`](diffhunk://#diff-136bf4d9e08380fc4e348ab8fa53b4bdd4cb085e277336ae07c21b59649fed89R1): Separated the symbol table into `doubleSymbolTable` and `stringSymbolTable` to manage different types of symbols. Added functions to set and get values from these tables. [[1]](diffhunk://#diff-136bf4d9e08380fc4e348ab8fa53b4bdd4cb085e277336ae07c21b59649fed89R1) [[2]](diffhunk://#diff-136bf4d9e08380fc4e348ab8fa53b4bdd4cb085e277336ae07c21b59649fed89L9-R11) [[3]](diffhunk://#diff-136bf4d9e08380fc4e348ab8fa53b4bdd4cb085e277336ae07c21b59649fed89L49-L85)

### Test updates:

* Updated test files to reflect changes in exception handling by replacing `prints` with `printe` in the catch blocks:
  * `project/tests/try_catch/2.ssc`
  * `project/tests/try_catch/3.ssc`
  * `project/tests/try_catch/5.ssc`
  * `project/tests/try_catch/6.ssc`